### PR TITLE
Update Dockerfile to support the new Firecracker release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN apk add --no-cache \
 ARG FIRECRACKER_VERSION
 # If amd64 is set, this is "-x86_64". If arm64, this should be "-aarch64".
 ARG FIRECRACKER_ARCH_SUFFIX
-RUN wget -qO- https://github.com/firecracker-microvm/firecracker/releases/download/${FIRECRACKER_VERSION}/firecracker-${FIRECRACKER_VERSION}${FIRECRACKER_ARCH_SUFFIX}.tgz | tar -xvz && \
+RUN mkdir -p release-${FIRECRACKER_VERSION}
+RUN wget -qO- https://github.com/firecracker-microvm/firecracker/releases/download/${FIRECRACKER_VERSION}/firecracker-${FIRECRACKER_VERSION}${FIRECRACKER_ARCH_SUFFIX}.tgz | tar -xvz -C release-${FIRECRACKER_VERSION} && \
     mv release-${FIRECRACKER_VERSION}/firecracker-${FIRECRACKER_VERSION}${FIRECRACKER_ARCH_SUFFIX} /usr/local/bin/firecracker && \
     rm -r release-${FIRECRACKER_VERSION}
 


### PR DESCRIPTION
Firecracker 0.24 tar file does not untar to a "release" directory. This update creates the release directory and untars the file there.